### PR TITLE
Create new Icons plugin based on existing plugin(s)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+(The MIT License)
+
+Copyright (c) 2014 Kura
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst LICENSE

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install uninstall pypi
+install:
+	python setup.py install
+
+uninstall:
+	pip uninstall pelican-fontawesome
+
+pypi:
+	python setup.py sdist upload
+	python setup.py bdist_wheel upload

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,6 @@ uninstall:
 	pip uninstall pelican-fontawesome
 
 pypi:
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+	pip install twine wheel
+	python setup.py sdist bdist_wheel
+	twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,46 @@
+===================
+Pelican FontAwesome
+===================
+
+Pelican FontAwesome allows you to embed FontAwesome icons in your RST documents.
+
+Installation
+============
+
+To install pelican-fontawesome, simply install it from PyPI:
+
+.. code-block:: bash
+
+    $ pip install pelican-fontawesome
+
+Then enabled it in your pelicanconf.py
+
+.. code-block:: python
+
+    PLUGINS = [
+        # ...
+        'pelican_fontawesome',
+        # ...
+    ]
+
+Usage
+=====
+
+In your article or page, you simply need to add a line to embed you video.
+
+.. code-block:: rst
+
+    :fa:`fa-github`
+
+Which will result in:
+
+.. code-block:: html
+
+    <span class="fa fa-github"></span>
+
+License
+=======
+
+`MIT`_ license.
+
+.. _MIT: http://opensource.org/licenses/MIT

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,9 @@
 Pelican FontAwesome
 ===================
 
-Pelican FontAwesome allows you to embed FontAwesome icons in your RST documents.
+Pelican FontAwesome allows you to embed `FontAwesome
+<https://fortawesome.github.io/Font-Awesome/>`__ icons in your RST posts and
+pages.
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,12 @@ Then enabled it in your pelicanconf.py
         # ...
     ]
 
+Include the FontAwesome CSS in your base template.
+
+.. code-block:: html
+
+    <link href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+
 Usage
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,8 @@ Include the FontAwesome CSS in your base template.
 Usage
 =====
 
-In your article or page, you simply need to add a line to embed you video.
+In your article or page, you simply need to add a reference to FontAwesome and
+then the icon name.
 
 .. code-block:: rst
 
@@ -43,6 +44,19 @@ Which will result in:
 .. code-block:: html
 
     <span class="fa fa-github"></span>
+
+And to the user will see: :fa:`fa-github`
+
+You can also increase the size, just like the `FontAwesome documentation
+<https://fortawesome.github.io/Font-Awesome/examples/>`__ shows.
+
+.. code-block:: rst
+
+    :fa:`fa-github fa-4x`
+
+Will result in: :fa:`fa-github fa-4x`
+
+
 
 License
 =======

--- a/pelican_fontawesome/__init__.py
+++ b/pelican_fontawesome/__init__.py
@@ -1,0 +1,35 @@
+# (The MIT License)
+
+# Copyright (c) 2014 Kura
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+__title__ = 'pelican-fontawesome'
+__version__ = '0.1.0'
+__author__ = 'Kura'
+__credits__ = ["Kura", ]
+__maintainer__ = "Kura"
+__email__ = "kura@kura.io"
+__status__ = "Stable"
+__license__ = 'MIT'
+__copyright__ = 'Copyright 2014'
+
+
+from .fontawesome import register

--- a/pelican_fontawesome/fontawesome.py
+++ b/pelican_fontawesome/fontawesome.py
@@ -1,0 +1,36 @@
+# (The MIT License)
+
+# Copyright (c) 2014 Kura
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import unicode_literals
+
+from docutils import nodes
+from docutils.parsers.rst import roles
+
+
+def fa(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    html = '<span class="fa {text}"></span>'.format(text=text)
+    return [nodes.raw('', html, format='html')], []
+
+
+def register():
+    roles.register_local_role('fa', fa)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[aliases]
+release = egg_info -RDb ''
+upload = upload --sign --identity=49FCF4D9
+
+[wheel]
+universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
-[aliases]
-release = egg_info -RDb ''
-upload = upload --sign --identity=49FCF4D9
-
 [wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+from setuptools import setup, find_packages
+
+version = __import__('pelican_fontawesome').__version__
+download_url = 'https://github.com/kura/pelican-fontawesome/archive/{}.zip'.format(version)
+
+setup(name='pelican-fontawesome',
+      version=version,
+      url='https://github.com/kura/pelican-fontawesome',
+      download_url=download_url,
+      author="Kura",
+      author_email="kura@kura.io",
+      maintainer="Kura",
+      maintainer_email="kura@kura.io",
+      description="Easily embed FontAwesome icons in your RST",
+      long_description=open("README.rst").read(),
+      license='MIT',
+      platforms=['linux'],
+      packages=find_packages(exclude=["*.tests"]),
+      package_data={'': ['LICENSE', ]},
+      classifiers=[
+          'Development Status :: 5 - Production/Stable',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.1',
+          'Programming Language :: Python :: 3.2',
+          'Programming Language :: Python :: 3.3',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Intended Audience :: Developers',
+          'License :: OSI Approved :: MIT License',
+          'Topic :: Internet :: WWW/HTTP',
+          'Topic :: Software Development :: Libraries :: Python Modules',
+          'Topic :: Text Processing',
+      ],
+      zip_safe=True,
+      )


### PR DESCRIPTION
## Objectives

Objectives for this plugin include:

- Migrate an [existing plugin](https://github.com/kura/pelican-fontawesome) and use the [Pelican Plugin Template](https://github.com/getpelican/cookiecutter-pelican-plugin) and the [Plugin Migration Guide](https://getpelican.com/blog/namespace-plugin-migration/) to modernize it.
- Ensure Markdown is supported ([existing plugin](https://github.com/kura/pelican-fontawesome) seems to only support reStructuredText)
- Structure the project in an agnostic manner, so that support for additional icon repositories can be added in the future without undue difficulty.

## Related Plugins

We might be able to take inspiration from the following related plugins as well:

- https://github.com/m-col/pelican-minify-fontawesome
- https://pypi.org/project/pelican-embed-svg/
- https://pypi.org/project/pelicanfly/

## Icon Repositories to Consider

Just some ideas for the future… 😊 

- https://github.com/simple-icons/simple-icons
- https://github.com/ionic-team/ionicons
- https://primer.style/design/foundations/icons
- https://joinfediverse.wiki/Draft:Fediverse_project_branding

